### PR TITLE
Update page title to reflect current role and affiliation

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const {
-	title = "Aniruddh Srivastava — Software Engineer, CS Honors @ Purdue University",
+	title = "Aniruddh Srivastava | Purdue | Cloudflare",
 	description = "Aniruddh Srivastava is a CS Honors student at Purdue University interested in systems programming, formal verification, and FPGA development. Incoming Cloudflare PM Intern.",
 } = Astro.props;
 ---


### PR DESCRIPTION
## Summary
Updated the default page title in the MainHead component to reflect current professional status and affiliations.

## Changes
- Modified the default `title` prop in `src/components/MainHead.astro` from a longer descriptive title to a more concise format
- Changed from: "Aniruddh Srivastava — Software Engineer, CS Honors @ Purdue University"
- Changed to: "Aniruddh Srivastava | Purdue | Cloudflare"

## Details
This change simplifies the page title while highlighting key affiliations (Purdue University and Cloudflare). The more detailed description remains available in the `description` prop for SEO and meta tag purposes.

https://claude.ai/code/session_019c5oyCvNEUz5sGotvvVxGt