### PR TITLE
Add robots.txt with AI crawl rules and Content Signals

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,73 @@
+# robots.txt for srivastava.dev / noir.ac
+# Policy: search engines welcome, AI training crawlers are not.
+# See: https://contentsignals.org/ and RFC 9309.
+
+User-agent: *
+Content-Signal: search=yes, ai-train=no, ai-input=no
+Allow: /
+
+# --- AI training crawlers: disallowed ---
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: AI2Bot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+# --- AI search surfacing (user-triggered or citation-linking): allowed ---
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+Sitemap: https://srivastava.dev/sitemap-index.xml


### PR DESCRIPTION
## Summary

- Adds `public/robots.txt` so `https://srivastava.dev/robots.txt` (and `noir.ac`) returns 200 with plain text.
- Declares Content Signals: `search=yes, ai-train=no, ai-input=no` — search engines welcome, AI training opted out.
- Explicit `Disallow: /` for 17 AI training crawlers (GPTBot, ClaudeBot, Claude-Web, anthropic-ai, Google-Extended, Applebot-Extended, Meta-ExternalAgent, FacebookBot, Amazonbot, Bytespider, CCBot, cohere-ai, PerplexityBot, AI2Bot, Diffbot, Omgilibot, Timpibot).
- Explicit `Allow: /` for search-surfacing / user-triggered bots (OAI-SearchBot, ChatGPT-User, Perplexity-User).
- References the auto-generated `sitemap-index.xml`.

Static file lives in `public/` and is served by the Cloudflare Workers assets binding — no Worker handler or route changes needed. Verified `npm run build` emits `dist/client/robots.txt`.

## Test plan

- [x] `npm run build` succeeds and emits `dist/client/robots.txt`
- [ ] After deploy: `curl -i https://srivastava.dev/robots.txt` returns 200 with `content-type: text/plain`
- [ ] After deploy: `curl -i https://noir.ac/robots.txt` returns 200
- [ ] Re-run the isitagentready.com checks — robots.txt / AI rules / Content Signals goals should pass
- [ ] Separately (dashboard, not this PR): enable **Markdown for Agents** on both zones in the Cloudflare dashboard; verify with `curl -sI -H "Accept: text/markdown" https://srivastava.dev/`
